### PR TITLE
Feat: 이메일 인증에서 중복 이메일 안내 문구 추가

### DIFF
--- a/GrowIT/Core/Components/Common/TextField.swift
+++ b/GrowIT/Core/Components/Common/TextField.swift
@@ -83,6 +83,7 @@ class CustomTextField: UIView {
         textField.leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 12.0, height: 0.0))
         textField.leftViewMode = .always
         textField.autocorrectionType = .no
+        textField.autocapitalizationType = .none
         textField.translatesAutoresizingMaskIntoConstraints = false
         
         // Clear Button 설정

--- a/GrowIT/Feat/Login/Presentation/ViewController/signupVC/EmailVerificationViewController.swift
+++ b/GrowIT/Feat/Login/Presentation/ViewController/signupVC/EmailVerificationViewController.swift
@@ -184,13 +184,7 @@ class EmailVerificationViewController: UIViewController {
                         disabledTitleColor: .gray400
                     )
                     
-                    // 토스트 메시지 표시
-                    let toastImage = UIImage(named: "Style=Mail") ?? UIImage()
-                    CustomToast(containerWidth: 225).show(
-                        image: toastImage,
-                        message: "인증번호를 발송했어요",
-                        font: UIFont.heading3SemiBold()
-                    )
+                    ToastSecond.show(image: UIImage(named: "Style=Mail") ?? UIImage(), message: "인증번호를 발송했어요", font: .heading3SemiBold(), in: self.view)
                     
                 case .failure(let error):
                     print("인증 메일 전송 실패: \(error)")

--- a/GrowIT/Feat/Login/Presentation/ViewController/signupVC/EmailVerificationViewController.swift
+++ b/GrowIT/Feat/Login/Presentation/ViewController/signupVC/EmailVerificationViewController.swift
@@ -154,16 +154,25 @@ class EmailVerificationViewController: UIViewController {
     }
     
     @objc private func sendCodeButtonTapped() {
-        guard let emailText = emailVerificationView.emailTextField.textField.text, !emailText.isEmpty else {
+        view.endEditing(true)
+        
+        guard let emailText = emailVerificationView.emailTextField.textField.text,
+              !emailText.isEmpty else {
             print("이메일 입력 필요")
             return
         }
         
-        self.view.endEditing(true)
-        
         email = emailText
-        
         let request = SendEmailVerifyRequest(email: emailText)
+        
+        // 👉 버튼 누르자마자 비활성화
+        emailVerificationView.sendCodeButton.setButtonState(
+            isEnabled: false,
+            enabledColor: .black,
+            disabledColor: .gray100,
+            enabledTitleColor: .white,
+            disabledTitleColor: .gray400
+        )
         
         authService.email(type: "SIGNUP", data: request) { result in
             DispatchQueue.main.async {
@@ -171,27 +180,28 @@ class EmailVerificationViewController: UIViewController {
                 case .success(let response):
                     print("인증 메일 전송 성공 이메일: \(response.email)")
                     print("응답 메시지: \(response.message)")
-
+                    
                     self.isEmailFieldDisabled = true
                     self.emailVerificationView.emailTextField.setTextFieldInteraction(enabled: false)
                     
-                    // 인증번호 보내기 버튼 비활성화
-                    self.emailVerificationView.sendCodeButton.setButtonState(
-                        isEnabled: false,
-                        enabledColor: .black,
-                        disabledColor: .gray100,
-                        enabledTitleColor: .white,
-                        disabledTitleColor: .gray400
+                    ToastSecond.show(
+                        image: UIImage(named: "Style=Mail") ?? UIImage(),
+                        message: "인증번호를 발송했어요",
+                        font: .heading3SemiBold(),
+                        in: self.view
                     )
-                    
-                    ToastSecond.show(image: UIImage(named: "Style=Mail") ?? UIImage(), message: "인증번호를 발송했어요", font: .heading3SemiBold(), in: self.view)
                     
                 case .failure(let error):
                     print("인증 메일 전송 실패: \(error)")
+                    
+                    if case .serverError(let statusCode, let message) = error,
+                       statusCode == 409 {
+                        // 👉 이미 가입된 이메일일 때 에러 처리
+                        self.emailVerificationView.emailTextField.setError(message: "이미 가입된 이메일입니다.")
+                    }
                 }
             }
         }
-        
     }
     
     @objc private func certificationButtonTapped() {


### PR DESCRIPTION
- CustomToast -> ToastSecond 로 변경
- 텍스트필드 대문자 자동 변환 none 으로 처리 
- 이미 가입된 이메일인 경우 에러 문구 추가 
- 기존 서버에서 발송 완료 시 비활성화 되는 버튼을 누르면 바로 비활성화 되게 함